### PR TITLE
add update functionality on /:team

### DIFF
--- a/public/js/site.js
+++ b/public/js/site.js
@@ -1,9 +1,11 @@
 Scavenger = function(){
 	this.team = $('#teamName');
 	this.toMap = $('#toMap');
+	this.update = $('#update');
 
-	this.toMap.on('click',this.getTeamGrams.bind(this));
 	this.team.on('keydown',this.onEnterDown.bind(this));
+	this.toMap.on('click',this.gramsFromForm.bind(this));
+	this.update.on('click',this.gramsFromUpdate.bind(this));
 };
 
 Scavenger.prototype.onEnterDown = function(event){
@@ -16,24 +18,35 @@ Scavenger.prototype.onEnterDown = function(event){
 	event.preventDefault();
 };
 
-Scavenger.prototype.getTeamGrams = function(event){
-	// get user input from form
-	var teamInput = this.team.val().trim();
-
+Scavenger.prototype.getTeamGrams = function(input){
 	$.ajax({
-		url: '/grams/' + teamInput,
+		url: '/grams/' + input,
 		type: 'POST',
-		data: {team: 'team' + teamInput},
+		data: {team: 'team' + input},
 		dataType: 'json'
-	}).done(function(){
+	}).done(function(data){
 		// redirect after ajax is finished
 		// this triggers a GET on the server
-		window.location.href = '/team' + teamInput;
+		window.location.href = '/team' + input;
 	});
+}
+
+Scavenger.prototype.gramsFromForm = function(event){
+	// get user input from form
+	var input = this.team.val().trim();
+
+	this.getTeamGrams(input);
 
 	event.preventDefault();
 };
 
+Scavenger.prototype.gramsFromUpdate= function(event){
+	var input = $('#name').data('id');
+	
+	this.getTeamGrams(input);
+
+	event.preventDefault();
+}
 
 Scavenger.prototype.createTeamPage = function(team){
 	//TODO better way to bind scope

--- a/server.js
+++ b/server.js
@@ -30,8 +30,11 @@ app.get('/',function(req,res){
 
 // team map
 app.get('/:team',function(req,res){
+	var originalName = req.params.team.substring(4);
+
 	res.render('pages/team', {
-		team: req.params.team
+		team: req.params.team,
+		original: originalName
 	});
 });
 

--- a/views/pages/team.ejs
+++ b/views/pages/team.ejs
@@ -4,7 +4,7 @@
 		<% include ../partials/head %>
 	</head>
 	<body>
-		<div class="row">
+		<div class="row" id="name" data-id="<%=original%>">
 			<h3 class="medium-7 medium-centered columns"><strong><%= team %></strong></h3>
 		</div>
 		<div class="row welcome">
@@ -16,7 +16,8 @@
 		</div>
 		<div class="row">
 			<div class="medium-7 medium-centered columns">
-				<a class="button expand" href="https://jue.cartodb.com/viz/b887b6ec-4487-11e5-ad67-0e853d047bba/embed_map" target="_blank"><strong>view map with all teams</strong></a></li>
+				<a id="update" href="#" class="button expand"><strong>Update my team progress</strong></a>
+				<a class="button secondary expand" href="https://jue.cartodb.com/viz/b887b6ec-4487-11e5-ad67-0e853d047bba/embed_map" target="_blank"><strong>view map with all teams</strong></a></li>
 			</div>
 		</div>
 	</body>


### PR DESCRIPTION
- use the same POST
- index gets input from form
- team page gets input from the `data-id` associated with the div containing team name

Feels a bit loopy. Definitely on the list for improvement. Something similar to Backbone's `navigate` would be nice.
